### PR TITLE
Target ES2020

### DIFF
--- a/packages/protovalidate/tsconfig.json
+++ b/packages/protovalidate/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "include": ["src/index.ts", "src/**/*.test.ts"],
-  "extends": "../../tsconfig.base.json"
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": [
+      // For Error.cause in error.ts and error.test.ts
+      "ES2022.Error"
+    ]
+  }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,14 +1,7 @@
 {
   "compilerOptions": {
-    // We target ES2020 because we (currently) use BigInt literals and require the Text Encoding API.
     "target": "es2020",
-    "lib": [
-      "ES2017",
-      // ES2020.BigInt for 64-bit integers
-      "ES2020.BigInt",
-      // ES2022.Error for Error.cause
-      "ES2022.Error"
-    ],
+    "lib": ["ES2020"],
     "declaration": true,
     "types": ["@types/node"],
     // We don't have dependencies that require interop


### PR DESCRIPTION
Cleaning up compiler targets and libs. We only need a single exception if we target ES2020: `Error.cause`. 
It's a relatively harmless feature to exempt, because we're never reading `cause` (except in tests).