### PR TITLE
Add note about the required Protobuf runtime to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ try {
 - [@bufbuild/protovalidate](https://www.npmjs.com/package/@bufbuild/protovalidate):
   Validates Protobuf messages at runtime based on user-defined validation rules.
 
+Note that protovalidate-es requires the Protobuf runtime [@bufbuild/protobuf](https://www.npmjs.com/package/@bufbuild/protobuf).
+
+
 ## Additional Languages and Repositories
 
 Protovalidate isn't just for ECMAScript! You might be interested in sibling repositories for other languages:

--- a/packages/protovalidate/README.md
+++ b/packages/protovalidate/README.md
@@ -52,6 +52,8 @@ try {
 > [!NOTE]
 > 
 > This version is compatible with [buf.build/bufbuild/protovalidate](https://buf.build/bufbuild/protovalidate) <!-- upstreamProtovalidateRef -->v0.11.0<!-- upstreamProtovalidateRef -->
+>
+> It requires the Protobuf runtime [@bufbuild/protobuf](https://www.npmjs.com/package/@bufbuild/protobuf).
 
 [protovalidate]: https://buf.build/docs/protovalidate
 [cel]: https://cel.dev


### PR DESCRIPTION
Protovalidate-ES validates Protobuf messages generated by [Protobuf-ES](https://github.com/bufbuild/protobuf-es). 

Other Protobuf runtimes are not supported. If a Protobuf runtime [supports reflection](https://github.com/bufbuild/protobuf-es/blob/v2.2.5/MANUAL.md#reflection), support is technically feasible, but not in scope for [@bufbuild/protovalidate](https://www.npmjs.com/package/@bufbuild/protovalidate).