### PR TITLE
Release 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1782,7 +1782,7 @@
     },
     "packages/protovalidate": {
       "name": "@bufbuild/protovalidate",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/cel": "^0.1.0"
@@ -1802,7 +1802,7 @@
       },
       "devDependencies": {
         "@bufbuild/protobuf": "^2.4.0",
-        "@bufbuild/protovalidate": "^0.1.0"
+        "@bufbuild/protovalidate": "^0.1.1"
       }
     }
   }

--- a/packages/protovalidate-testing/package.json
+++ b/packages/protovalidate-testing/package.json
@@ -17,6 +17,6 @@
   "sideEffects": false,
   "devDependencies": {
     "@bufbuild/protobuf": "^2.4.0",
-    "@bufbuild/protovalidate": "^0.1.0"
+    "@bufbuild/protovalidate": "^0.1.1"
   }
 }

--- a/packages/protovalidate/package.json
+++ b/packages/protovalidate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufbuild/protovalidate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Protocol Buffer Validation for ECMAScript",
   "keywords": [
     "javascript",


### PR DESCRIPTION
## What's Changed
* Fix CEL bindings for "this", "rule" with integers by @timostamm in https://github.com/bufbuild/protovalidate-es/pull/15
* Replace path.ts with types from @bufbuild/protobuf/reflect v2.3.0  by @timostamm in https://github.com/bufbuild/protovalidate-es/pull/18
* Automatically add referenced types to the registry by @timostamm in https://github.com/bufbuild/protovalidate-es/pull/21


**Full Changelog**: https://github.com/bufbuild/protovalidate-es/compare/v0.1.0...v0.1.1