### PR TITLE
Support validation of legacy required fields

### DIFF
--- a/packages/protovalidate/src/eval.ts
+++ b/packages/protovalidate/src/eval.ts
@@ -175,6 +175,20 @@ export class EvalFieldRequired implements Eval<ReflectMessage> {
   }
 }
 
+export class EvalFieldLegacyRequired implements Eval<ReflectMessage> {
+  constructor(private readonly field: DescField) {}
+  eval(val: ReflectMessage, cursor: Cursor): void {
+    if (!val.isSet(this.field)) {
+      cursor
+        .field(this.field)
+        .violate("value is required", "legacy_required", []);
+    }
+  }
+  prune(): boolean {
+    return false;
+  }
+}
+
 export class EvalOneofRequired implements Eval<ReflectMessage> {
   constructor(private readonly oneof: DescOneof) {}
 


### PR DESCRIPTION
This PR adds the validator option `legacyRequired`:

```ts
import { createValidator } from "@bufbuild/protovalidate";

const v = createValidator({
  legacyRequired: true,
});
```


With this option enabled, proto2 fields with the `required` label, and fields with the edition feature  `field_presence=LEGACY_REQUIRED` are validated to be set. By default, legacy required field are not validated.