### PR TITLE
Re-use validator in conformance tests

### DIFF
--- a/packages/protovalidate-testing/src/executor.ts
+++ b/packages/protovalidate-testing/src/executor.ts
@@ -39,6 +39,7 @@ if (!request.fdset) {
   throw new Error(`Empty request field "fdset"`);
 }
 const registry = createFileRegistry(request.fdset);
+const validator = createValidator({ registry });
 
 for (const [name, any] of Object.entries(request.cases)) {
   let r: TestResult["result"];
@@ -47,7 +48,7 @@ for (const [name, any] of Object.entries(request.cases)) {
     if (!unpacked) {
       throw new Error(`Unable to unpack Any with type_url "${any.typeUrl}"`);
     }
-    createValidator({ registry }).validate(unpacked.schema, unpacked.message);
+    validator.validate(unpacked.schema, unpacked.message);
     r = { case: "success", value: true };
   } catch (e) {
     if (e instanceof ValidationError) {


### PR DESCRIPTION
This makes conformance tests ~30% faster (11.8s instead of 16.8 on my machine).