### PR TITLE
Change Validator.validate to return result

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,9 @@ import { MoneyTransferSchema } from "./gen/banking_pb";
 
 const transfer = create(MoneyTransferSchema);
 
-const v = createValidator();
-
-try {
-  v.validate(MoneyTransferSchema, transfer);
-} catch (e) {
+const validator = createValidator();
+const result = validator.validate(MoneyTransferSchema, transfer);
+if (result.kind !== "valid") {
   // Handle failure.
 }
 ```

--- a/packages/protovalidate/README.md
+++ b/packages/protovalidate/README.md
@@ -40,13 +40,12 @@ import { MoneyTransferSchema } from "./gen/banking_pb";
 
 const transfer = create(MoneyTransferSchema);
 
-const v = createValidator();
-
-try {
-  v.validate(MoneyTransferSchema, transfer);
-} catch (e) {
+const validator = createValidator();
+const result = validator.validate(MoneyTransferSchema, transfer);
+if (result.kind !== "valid") {
   // Handle failure.
 }
+
 ```
 
 > [!NOTE]

--- a/packages/protovalidate/src/result.ts
+++ b/packages/protovalidate/src/result.ts
@@ -12,6 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from "./validator.js";
-export * from "./result.js";
-export * from "./error.js";
+import type {
+  CompilationError,
+  RuntimeError,
+  ValidationError,
+  Violation,
+} from "./error.js";
+
+/**
+ * The result of validating a Protobuf message with protovalidate.
+ */
+export type ValidationResult =
+  | {
+      kind: "valid";
+      error: undefined;
+      violations: undefined;
+    }
+  | {
+      kind: "invalid";
+      error: ValidationError;
+      violations: Violation[];
+    }
+  | {
+      kind: "error";
+      error: CompilationError | RuntimeError;
+      violations: undefined;
+    };

--- a/packages/protovalidate/src/result.ts
+++ b/packages/protovalidate/src/result.ts
@@ -21,6 +21,11 @@ import type {
 
 /**
  * The result of validating a Protobuf message with protovalidate.
+ *
+ * It is one of:
+ * - valid: The message passed all validation rules.
+ * - invalid: The message violated one or more validation rules.
+ * - error: An error occurred while compiling or evaluating a rule.
  */
 export type ValidationResult =
   | {

--- a/packages/protovalidate/src/validator.test.ts
+++ b/packages/protovalidate/src/validator.test.ts
@@ -42,13 +42,13 @@ const bufCompileOptions = {
 
 void suite("Validator", () => {
   void test("validate() returns result", () => {
-    const v: Validator = createValidator();
+    const validator: Validator = createValidator();
     const descMessage = compileMessage(`
       syntax = "proto3";
       message M {}
     `);
     const message = create(descMessage);
-    const result = v.validate(descMessage, message);
+    const result = validator.validate(descMessage, message);
     const resultError:
       | ValidationError
       | RuntimeError

--- a/packages/protovalidate/src/validator.test.ts
+++ b/packages/protovalidate/src/validator.test.ts
@@ -17,9 +17,14 @@ import { suite, test } from "node:test";
 import { readFileSync } from "node:fs";
 import { create, type DescMessage } from "@bufbuild/protobuf";
 import { compileFile, compileMessage } from "@bufbuild/protocompile";
-import { type CompilationError, RuntimeError, type ValidationError, type Violation} from "./error.js";
+import {
+  type CompilationError,
+  RuntimeError,
+  type ValidationError,
+  type Violation,
+} from "./error.js";
 import { DurationSchema, TimestampSchema } from "@bufbuild/protobuf/wkt";
-import { createValidator, type Validator} from "./validator.js";
+import { createValidator, type Validator } from "./validator.js";
 
 void test("createValidator() returns Validator", () => {
   const v = createValidator();
@@ -44,7 +49,11 @@ void suite("Validator", () => {
     `);
     const message = create(descMessage);
     const result = v.validate(descMessage, message);
-    const resultError: ValidationError | RuntimeError | CompilationError | undefined = result.error;
+    const resultError:
+      | ValidationError
+      | RuntimeError
+      | CompilationError
+      | undefined = result.error;
     const resultViolations: Violation[] | undefined = result.violations;
     assert.ok(resultError || resultViolations || true);
     switch (result.kind) {
@@ -69,7 +78,7 @@ void suite("Validator", () => {
     const validator = createValidator();
     const schema = TimestampSchema as DescMessage;
     const message = create(DurationSchema);
-    const result = validator.validate(schema, message)
+    const result = validator.validate(schema, message);
     assert.equal(result.kind, "error");
     assert.ok(result.error instanceof RuntimeError);
     assert.equal(


### PR DESCRIPTION
> [!IMPORTANT]  
> This is a breaking change to the type `Validator`. 
> We're removing the method `for`, and we're changing the behavior of the method `validate`.

Before, the `Validator` method `validate` would raise an error if a message is invalid, or if an error occurred.

With this change, the method `validate` returns a `ValidationResult`. It is one of:
- valid: The message passed all validation rules.
- invalid: The message violated one or more validation rules.
- error: An error occurred while compiling or evaluating a rule.

```ts
import type { ValidationResult } from "@bufbuild/protovalidate";

const result: ValidationResult = validator.validate(descMessage, message);

switch (result.kind) {

  case "valid":
    // Validation passed
    break;

  case "invalid":
    // Validation failed
    result.violations; // Violation[]
    result.error; // ValidationError
    break;
    
  case "error":
    result.error; // RuntimeError | CompilationError
    break;
}
```

The changes simplify the API. We hope to bring back an equivalent feature before cutting a release.