### PR TITLE
Release 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1801,11 +1801,11 @@
     },
     "packages/example": {
       "name": "protovalidate-example",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.5.0",
-        "@bufbuild/protovalidate": "^0.1.0"
+        "@bufbuild/protovalidate": "^0.2.0"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.54.0",
@@ -1814,7 +1814,7 @@
     },
     "packages/protovalidate": {
       "name": "@bufbuild/protovalidate",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/cel": "^0.1.0"
@@ -1835,7 +1835,7 @@
       },
       "devDependencies": {
         "@bufbuild/protobuf": "^2.5.0",
-        "@bufbuild/protovalidate": "^0.1.1"
+        "@bufbuild/protovalidate": "^0.2.0"
       }
     }
   }

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protovalidate-example",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@bufbuild/protovalidate": "^0.1.0",
+    "@bufbuild/protovalidate": "^0.2.0",
     "@bufbuild/protobuf": "^2.5.0"
   },
   "devDependencies": {

--- a/packages/protovalidate-testing/package.json
+++ b/packages/protovalidate-testing/package.json
@@ -17,6 +17,6 @@
   "sideEffects": false,
   "devDependencies": {
     "@bufbuild/protobuf": "^2.5.0",
-    "@bufbuild/protovalidate": "^0.1.1"
+    "@bufbuild/protovalidate": "^0.2.0"
   }
 }

--- a/packages/protovalidate/package.json
+++ b/packages/protovalidate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufbuild/protovalidate",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Protocol Buffer Validation for ECMAScript",
   "keywords": [
     "javascript",


### PR DESCRIPTION
## Breaking Changes

The `validate` method of `Validator` changes behavior: Before, the method would raise an error if a message is invalid, or if an error occurred. With this release, the method returns a `ValidationResult` instead. 

For details, see https://github.com/bufbuild/protovalidate-es/pull/27 and the newly added [example](https://github.com/bufbuild/protovalidate-es/tree/main/packages/example#readme). This change allows us to support [Valid types](https://github.com/bufbuild/protovalidate-es/pull/29). 



## What's Changed
* Support validation of legacy required fields by @timostamm in https://github.com/bufbuild/protovalidate-es/pull/24
* Raise a RuntimeError if the schema and message provided to the validator do not match by @timostamm in https://github.com/bufbuild/protovalidate-es/pull/25
* Update to protovalidate v0.11.1 by @timostamm in https://github.com/bufbuild/protovalidate-es/pull/28
* Change Validator.validate to return result by @timostamm in https://github.com/bufbuild/protovalidate-es/pull/27
* Add example by @timostamm in https://github.com/bufbuild/protovalidate-es/pull/30
* Update @bufbuild/protobuf to v2.5.0 by @timostamm in https://github.com/bufbuild/protovalidate-es/pull/31
* Support Valid types by @timostamm in https://github.com/bufbuild/protovalidate-es/pull/29


**Full Changelog**: https://github.com/bufbuild/protovalidate-es/compare/v0.1.1...v0.2.0