### PR TITLE
Add Standard Schema v1 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -976,6 +976,13 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.15.29",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
@@ -1809,7 +1816,8 @@
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.54.0",
-        "@bufbuild/protoc-gen-es": "^2.5.1"
+        "@bufbuild/protoc-gen-es": "^2.5.1",
+        "@standard-schema/spec": "^1.0.0"
       }
     },
     "packages/protovalidate": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -14,11 +14,12 @@
   },
   "type": "module",
   "dependencies": {
-    "@bufbuild/protovalidate": "^0.4.0",
-    "@bufbuild/protobuf": "^2.5.0"
+    "@bufbuild/protobuf": "^2.5.0",
+    "@bufbuild/protovalidate": "^0.4.0"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.54.0",
-    "@bufbuild/protoc-gen-es": "^2.5.1"
+    "@bufbuild/protoc-gen-es": "^2.5.1",
+    "@standard-schema/spec": "^1.0.0"
   }
 }

--- a/packages/example/src/standard-schema.ts
+++ b/packages/example/src/standard-schema.ts
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {create} from "@bufbuild/protobuf";
-import {createStandardSchema} from "@bufbuild/protovalidate";
+import { create } from "@bufbuild/protobuf";
+import { createStandardSchema } from "@bufbuild/protovalidate";
 import {
   OrderSchema,
   type OrderValid,
   type User,
 } from "./gen/store/v1/order_pb.js";
-import {StandardSchemaV1} from "@standard-schema/spec";
+import { StandardSchemaV1 } from "@standard-schema/spec";
 
 async function standardValidate<T extends StandardSchemaV1>(
   schema: T,

--- a/packages/example/src/standard-schema.ts
+++ b/packages/example/src/standard-schema.ts
@@ -1,0 +1,53 @@
+// Copyright 2024-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { create } from "@bufbuild/protobuf";
+import {
+  createStandardSchema,
+  type StandardSchemaV1,
+} from "@bufbuild/protovalidate";
+import { MoneyTransferSchema } from "./gen/banking/v1/money_transfer_pb.js";
+
+async function standardValidate<T extends StandardSchemaV1>(
+  schema: T,
+  input: StandardSchemaV1.InferInput<T>,
+): Promise<StandardSchemaV1.Result<StandardSchemaV1.InferOutput<T>>> {
+  const result = schema["~standard"].validate(input);
+  // Handle both sync and async results
+  return Promise.resolve(result);
+}
+
+async function validate() {
+  const schema = createStandardSchema(MoneyTransferSchema);
+
+  const transfer = create(MoneyTransferSchema, {
+    toAccountId: "550e8400-e29b-41d4-a716-446655440000",
+    fromAccountId: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+  });
+
+  const result = await standardValidate(schema, transfer);
+
+  if ("issues" in result) {
+    console.log("❌ Invalid! Found", result.issues?.length || 0, "issues:");
+    result.issues?.forEach((issue, i) => {
+      // Issues have a message and optional path
+      const path = issue.path ? issue.path.join(".") : "root";
+      console.log(`  ${i + 1}. [${path}] ${issue.message}`);
+    });
+  } else {
+    console.log("✅ Valid! The validated value is:", result.value);
+  }
+}
+
+validate();

--- a/packages/protovalidate/src/index.ts
+++ b/packages/protovalidate/src/index.ts
@@ -14,3 +14,4 @@
 
 export * from "./validator.js";
 export * from "./error.js";
+export * from "./standard-schema.js";

--- a/packages/protovalidate/src/index.ts
+++ b/packages/protovalidate/src/index.ts
@@ -14,4 +14,4 @@
 
 export * from "./validator.js";
 export * from "./error.js";
-export * from "./standard-schema.js";
+export { createStandardSchema } from "./standard-schema.js";

--- a/packages/protovalidate/src/standard-schema.test.ts
+++ b/packages/protovalidate/src/standard-schema.test.ts
@@ -1,0 +1,355 @@
+// Copyright 2024-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "node:assert";
+import { suite, test } from "node:test";
+import { readFileSync } from "node:fs";
+import { create } from "@bufbuild/protobuf";
+import { compileMessage } from "@bufbuild/protocompile";
+import {
+  createStandardSchema,
+  type StandardSchemaV1,
+} from "./standard-schema.js";
+
+const bufCompileOptions = {
+  imports: {
+    "buf/validate/validate.proto": readFileSync(
+      "proto/buf/validate/validate.proto",
+      "utf-8",
+    ),
+  },
+};
+
+void suite("createStandardSchema", () => {
+  void suite("basic functionality", () => {
+    void test("creates StandardSchemaV1 compliant validator", () => {
+      const descMessage = compileMessage(`
+      syntax = "proto3";
+      message TestMessage {
+        string name = 1;
+      }
+    `);
+
+      const schema = createStandardSchema(descMessage);
+
+      // Check structure
+      assert.ok(schema["~standard"]);
+      assert.equal(schema["~standard"].version, 1);
+      assert.equal(schema["~standard"].vendor, "protovalidate-es");
+      assert.equal(typeof schema["~standard"].validate, "function");
+    });
+
+    void test("validates message without rules", () => {
+      const descMessage = compileMessage(`
+        syntax = "proto3";
+        message User {
+          string email = 1;
+          int32 age = 2;
+        }
+      `);
+
+      const schema = createStandardSchema(descMessage);
+      const message = create(descMessage, {
+        email: "test@example.com",
+        age: 25,
+      });
+      const result = schema["~standard"].validate(
+        message,
+      ) as StandardSchemaV1.Result<{ email: string; age: number }>;
+
+      assert.ok(!(result instanceof Promise));
+      assert.equal(result.issues, undefined);
+      assert.ok("value" in result && result.value);
+      assert.equal(result.value.email, "test@example.com");
+      assert.equal(result.value.age, 25);
+    });
+
+    void test("returns issues for invalid input type", () => {
+      const descMessage = compileMessage(`
+        syntax = "proto3";
+        message User {
+          string email = 1;
+          int32 age = 2;
+        }
+      `);
+
+      const schema = createStandardSchema(descMessage);
+      const result = schema["~standard"].validate("not an object");
+
+      assert.ok(!(result instanceof Promise));
+      assert.ok("issues" in result && result.issues);
+      assert.ok(Array.isArray(result.issues));
+      assert.equal(result.issues.length, 1);
+      assert.equal(result.issues[0].message, "Expected an object");
+    });
+
+    void test("handles non-object input", () => {
+      const descMessage = compileMessage(`
+      syntax = "proto3";
+      message TestMessage {
+        string name = 1;
+      }
+    `);
+
+      const schema = createStandardSchema(descMessage);
+
+      // Test with null
+      let result = schema["~standard"].validate(null);
+      assert.ok(!(result instanceof Promise));
+      assert.ok("issues" in result && result.issues);
+      assert.equal(result.issues.length, 1);
+      assert.equal(result.issues[0].message, "Expected an object");
+
+      // Test with string
+      result = schema["~standard"].validate("not an object");
+      assert.ok(!(result instanceof Promise));
+      assert.ok("issues" in result && result.issues);
+      assert.equal(result.issues.length, 1);
+      assert.equal(result.issues[0].message, "Expected an object");
+
+      // Test with number
+      result = schema["~standard"].validate(42);
+      assert.ok(!(result instanceof Promise));
+      assert.ok("issues" in result && result.issues);
+      assert.equal(result.issues.length, 1);
+      assert.equal(result.issues[0].message, "Expected an object");
+    });
+  });
+
+  void suite("validation rules", () => {
+    void test("validates standard rule", () => {
+      const descMessage = compileMessage(
+        `
+        syntax = "proto3";
+        import "buf/validate/validate.proto";
+        message User {
+          string email = 1 [(buf.validate.field).string.email = true];
+        }
+      `,
+        bufCompileOptions,
+      );
+
+      const schema = createStandardSchema(descMessage);
+
+      // Valid email
+      const validMessage = create(descMessage, { email: "test@example.com" });
+      const validResult = schema["~standard"].validate(validMessage);
+      assert.ok(!(validResult instanceof Promise));
+      assert.equal(validResult.issues, undefined);
+      assert.ok("value" in validResult && validResult.value);
+
+      // Invalid email
+      const invalidMessage = create(descMessage, { email: "not-an-email" });
+      const invalidResult = schema["~standard"].validate(invalidMessage);
+      assert.ok(!(invalidResult instanceof Promise));
+      assert.ok("issues" in invalidResult && invalidResult.issues);
+      assert.equal(invalidResult.issues.length, 1);
+      assert.deepEqual(invalidResult.issues[0].path, ["email"]);
+      assert.ok(invalidResult.issues[0].message.includes("email"));
+    });
+
+    void test("validates CEL custom rules", () => {
+      const descMessage = compileMessage(
+        `
+        syntax = "proto3";
+        import "buf/validate/validate.proto";
+        message PasswordReset {
+          string password = 1 [(buf.validate.field).string.min_len = 8];
+          string confirm_password = 2;
+
+          option (buf.validate.message).cel = {
+            id: "passwords_must_match"
+            message: "passwords must match"
+            expression: "this.password == this.confirm_password"
+          };
+        }
+      `,
+        bufCompileOptions,
+      );
+
+      const schema = createStandardSchema(descMessage);
+
+      // Matching passwords
+      const validMessage = create(descMessage, {
+        password: "securepass123",
+        confirmPassword: "securepass123",
+      });
+      const validResult = schema["~standard"].validate(validMessage);
+      assert.ok(!(validResult instanceof Promise));
+      assert.equal(validResult.issues, undefined);
+      assert.ok("value" in validResult && validResult.value);
+
+      // Non-matching passwords
+      const invalidMessage = create(descMessage, {
+        password: "securepass123",
+        confirmPassword: "different456",
+      });
+      const invalidResult = schema["~standard"].validate(invalidMessage);
+      assert.ok("issues" in invalidResult && invalidResult.issues);
+      assert.equal(invalidResult.issues.length, 1);
+      assert.equal(invalidResult.issues[0].message, "passwords must match");
+      assert.equal(invalidResult.issues[0].path, undefined); // Message-level error has no path
+    });
+  });
+
+  void suite("error path conversions", () => {
+    void test("converts nested field paths", () => {
+      const descMessage = compileMessage(
+        `
+        syntax = "proto3";
+        import "buf/validate/validate.proto";
+        message User {
+          message Address {
+            string street = 1 [(buf.validate.field).string.min_len = 1];
+            string city = 2 [(buf.validate.field).string.min_len = 1];
+          }
+          string name = 1;
+          Address address = 2;
+        }
+      `,
+        bufCompileOptions,
+      );
+
+      const schema = createStandardSchema(descMessage);
+      const message = create(descMessage, {
+        name: "John",
+        address: {
+          street: "", // Invalid: empty street
+          city: "NYC",
+        },
+      });
+      const result = schema["~standard"].validate(message);
+
+      assert.ok("issues" in result && result.issues);
+      assert.equal(result.issues.length, 1);
+      assert.deepEqual(result.issues[0].path, ["address", "street"]);
+    });
+
+    void test("converts repeated field paths", () => {
+      const descMessage = compileMessage(
+        `
+        syntax = "proto3";
+        import "buf/validate/validate.proto";
+        message EmailList {
+          repeated string emails = 1 [(buf.validate.field).repeated = {
+            items: {string: {email: true}}
+          }];
+        }
+      `,
+        bufCompileOptions,
+      );
+
+      const schema = createStandardSchema(descMessage);
+      const message = create(descMessage, {
+        emails: ["valid@example.com", "invalid-email", "another@valid.com"],
+      });
+      const result = schema["~standard"].validate(message);
+
+      assert.ok("issues" in result && result.issues);
+      assert.equal(result.issues.length, 1);
+      assert.deepEqual(result.issues[0].path, ["emails", 1]); // Index 1 is invalid
+    });
+
+    void test("converts map field paths", () => {
+      const descMessage = compileMessage(
+        `
+        syntax = "proto3";
+        import "buf/validate/validate.proto";
+        message ScoreBoard {
+          map<string, int32> scores = 1 [(buf.validate.field).map = {
+            values: {int32: {gte: 0, lte: 100}}
+          }];
+        }
+      `,
+        bufCompileOptions,
+      );
+
+      const schema = createStandardSchema(descMessage);
+      const message = create(descMessage, {
+        scores: {
+          math: 95,
+          english: 150, // Invalid: > 100
+          science: 85,
+        },
+      });
+      const result = schema["~standard"].validate(message);
+
+      assert.ok("issues" in result && result.issues);
+      assert.equal(result.issues.length, 1);
+      assert.deepEqual(result.issues[0].path, ["scores", "english"]);
+    });
+
+    void test("handles multiple validation errors", () => {
+      const descMessage = compileMessage(
+        `
+        syntax = "proto3";
+        import "buf/validate/validate.proto";
+        message User {
+          string email = 1 [(buf.validate.field).string.email = true];
+          int32 age = 2 [(buf.validate.field).int32 = {gte: 18}];
+          string username = 3 [(buf.validate.field).string = {min_len: 3}];
+        }
+      `,
+        bufCompileOptions,
+      );
+
+      const schema = createStandardSchema(descMessage);
+      const message = create(descMessage, {
+        email: "not-an-email",
+        age: 15,
+        username: "ab",
+      });
+      const result = schema["~standard"].validate(message);
+
+      assert.ok("issues" in result && result.issues);
+      assert.equal(result.issues.length, 3);
+
+      // Check that we have errors for all three fields
+      const paths = result.issues.map(
+        (issue: StandardSchemaV1.Issue) => issue.path?.[0],
+      );
+      assert.ok(paths.includes("email"));
+      assert.ok(paths.includes("age"));
+      assert.ok(paths.includes("username"));
+    });
+
+    void test("handles CEL compilation errors", () => {
+      const descMessage = compileMessage(
+        `
+        syntax = "proto3";
+        import "buf/validate/validate.proto";
+        message BadCEL {
+          string value = 1 [(buf.validate.field).cel = {
+            id: "bad_cel"
+            message: "Invalid CEL"
+            expression: "this.invalid.syntax("
+          }];
+        }
+      `,
+        bufCompileOptions,
+      );
+
+      const schema = createStandardSchema(descMessage);
+      const message = create(descMessage, { value: "test" });
+      const result = schema["~standard"].validate(message);
+
+      assert.ok("issues" in result && result.issues);
+      assert.equal(result.issues.length, 1);
+      assert.ok(
+        result.issues[0].message.includes("CEL") ||
+          result.issues[0].message.includes("compile"),
+      );
+    });
+  });
+});

--- a/packages/protovalidate/src/standard-schema.ts
+++ b/packages/protovalidate/src/standard-schema.ts
@@ -1,0 +1,218 @@
+// Copyright 2024-2025 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {
+  DescMessage,
+  MessageShape,
+  MessageValidType,
+} from "@bufbuild/protobuf";
+import { createValidator, type ValidatorOptions } from "./validator.js";
+import type { Violation } from "./error.js";
+
+/**
+ * Convert a Violation to a StandardSchemaV1.Issue.
+ */
+function violationToIssue(violation: Violation): StandardSchemaV1.Issue {
+  const path: Array<PropertyKey> = [];
+
+  for (const segment of violation.field) {
+    switch (segment.kind) {
+      case "field":
+        path.push(segment.name);
+        continue;
+      case "oneof":
+        path.push(segment.name);
+        continue;
+      case "list_sub":
+        path.push(segment.index);
+        continue;
+      case "map_sub":
+        const key = segment.key;
+        if (typeof key === "string" || typeof key === "number") {
+          path.push(key);
+        } else {
+          path.push(String(key));
+        }
+        continue;
+      case "extension":
+        // Extensions are represented as field names with brackets
+        path.push(`[${segment.typeName}]`);
+        continue;
+    }
+  }
+
+  if (path.length > 0) {
+    return {
+      message: violation.message,
+      path: path,
+    };
+  }
+
+  return {
+    message: violation.message,
+  };
+}
+
+/**
+ * Create a Standard Schema compliant validator for a Protobuf message type.
+ *
+ * @param messageDesc - The Protobuf message descriptor
+ * @param options - Optional validator configuration
+ * @returns A StandardSchemaV1 compliant validator
+ */
+export function createStandardSchema<Desc extends DescMessage>(
+  messageDesc: Desc,
+  options?: ValidatorOptions,
+): StandardSchemaV1<MessageShape<Desc>, MessageValidType<Desc>> {
+  const validator = createValidator(options);
+
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "protovalidate-es",
+      validate: (value: unknown) => {
+        // Type guard to ensure value is an object
+        if (typeof value !== "object" || value === null) {
+          return {
+            issues: [
+              {
+                message: "Expected an object",
+              },
+            ],
+          };
+        }
+
+        const result = validator.validate(
+          messageDesc,
+          value as MessageShape<Desc>,
+        );
+
+        switch (result.kind) {
+          case "valid":
+            return {
+              value: result.message,
+            };
+
+          case "invalid":
+            return {
+              issues: result.violations.map(violationToIssue),
+            };
+
+          case "error":
+            // For compilation/runtime errors, we return them as issues
+            return {
+              issues: [
+                {
+                  message: result.error.message,
+                },
+              ],
+            };
+        }
+      },
+      types: {
+        input: undefined as unknown as MessageShape<Desc>,
+        output: undefined as unknown as MessageValidType<Desc>,
+      },
+    },
+  };
+}
+
+/*
+ * The Standard Schema interface.
+ *
+ * Derived from Standard Schema (MIT)
+ * https://github.com/standard-schema/standard-schema
+ *
+ * Copyright (c) 2024 Colin McDonnell
+ */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+  /** The Standard Schema properties. */
+  readonly "~standard": StandardSchemaV1.Props<Input, Output>;
+}
+
+/*
+ * The Standard Schema namespace.
+ *
+ * Derived from Standard Schema (MIT)
+ * https://github.com/standard-schema/standard-schema
+ *
+ * Copyright (c) 2024 Colin McDonnell
+ */
+export declare namespace StandardSchemaV1 {
+  /** The Standard Schema properties interface. */
+  export interface Props<Input = unknown, Output = Input> {
+    /** The version number of the standard. */
+    readonly version: 1;
+    /** The vendor name of the schema library. */
+    readonly vendor: string;
+    /** Validates unknown input values. */
+    readonly validate: (
+      value: unknown,
+    ) => Result<Output> | Promise<Result<Output>>;
+    /** Inferred types associated with the schema. */
+    readonly types?: Types<Input, Output> | undefined;
+  }
+
+  /** The result interface of the validate function. */
+  export type Result<Output> = SuccessResult<Output> | FailureResult;
+
+  /** The result interface if validation succeeds. */
+  export interface SuccessResult<Output> {
+    /** The typed output value. */
+    readonly value: Output;
+    /** The non-existent issues. */
+    readonly issues?: undefined;
+  }
+
+  /** The result interface if validation fails. */
+  export interface FailureResult {
+    /** The issues of failed validation. */
+    readonly issues: ReadonlyArray<Issue>;
+  }
+
+  /** The issue interface of the failure output. */
+  export interface Issue {
+    /** The error message of the issue. */
+    readonly message: string;
+    /** The path of the issue, if any. */
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
+  }
+
+  /** The path segment interface of the issue. */
+  export interface PathSegment {
+    /** The key representing a path segment. */
+    readonly key: PropertyKey;
+  }
+
+  /** The Standard Schema types interface. */
+  export interface Types<Input = unknown, Output = Input> {
+    /** The input type of the schema. */
+    readonly input: Input;
+    /** The output type of the schema. */
+    readonly output: Output;
+  }
+
+  /** Infers the input type of a Standard Schema. */
+  export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema["~standard"]["types"]
+  >["input"];
+
+  /** Infers the output type of a Standard Schema. */
+  export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema["~standard"]["types"]
+  >["output"];
+
+  // biome-ignore lint/complexity/noUselessEmptyExport: needed for granular visibility control of TS namespace
+  export {};
+}

--- a/packages/protovalidate/src/standard-schema.ts
+++ b/packages/protovalidate/src/standard-schema.ts
@@ -120,6 +120,11 @@ export function createStandardSchema<Desc extends DescMessage>(
             };
         }
       },
+      // Standard Schema types property for static analysis and type inference.
+      // This property provides type information to external tools and libraries
+      // for extracting input/output types using InferInput<T> and InferOutput<T>.
+      // Runtime values are intentionally set to undefined to minimize overhead
+      // while maintaining full TypeScript type information.
       types: {
         input: undefined as unknown as MessageShape<Desc>,
         output: undefined as unknown as MessageValidType<Desc>,


### PR DESCRIPTION
## Description

Closes #52

This PR introduces a new utility, `createStandardSchema`, which generates a Standard Schema v1 compliant validator for Protobuf message types. The main features and changes are as follows:

- Implements the `StandardSchemaV1` interface, following the [standard-schema](https://github.com/standard-schema/standard-schema) specification.
- Provides a `validate` method that returns results in the Standard Schema format, including detailed issues with error messages and paths.
- Converts internal `Violation` objects to Standard Schema `Issue` objects, ensuring compatibility and clarity in error reporting.
- Supports both input and output type inference via the `types` property.
- Handles all validation outcomes: valid, invalid (with issues), and runtime errors.

This addition improves interoperability with tools and libraries that support the Standard Schema, and makes it easier to integrate Protobuf validation into broader validation workflows.