### PR TITLE
Release `0.6.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1813,11 +1813,11 @@
     },
     "packages/example": {
       "name": "protovalidate-example",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.6.1",
-        "@bufbuild/protovalidate": "^0.5.0"
+        "@bufbuild/protovalidate": "^0.6.0"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.55.1",
@@ -1827,7 +1827,7 @@
     },
     "packages/protovalidate": {
       "name": "@bufbuild/protovalidate",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/cel": "0.2.0"
@@ -1846,7 +1846,7 @@
       "name": "@bufbuild/protovalidate-testing",
       "devDependencies": {
         "@bufbuild/protobuf": "^2.6.1",
-        "@bufbuild/protovalidate": "^0.5.0",
+        "@bufbuild/protovalidate": "^0.6.0",
         "upstream": "*"
       }
     },

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protovalidate-example",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
@@ -15,7 +15,7 @@
   "type": "module",
   "dependencies": {
     "@bufbuild/protobuf": "^2.6.1",
-    "@bufbuild/protovalidate": "^0.5.0"
+    "@bufbuild/protovalidate": "^0.6.0"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.55.1",

--- a/packages/protovalidate-testing/package.json
+++ b/packages/protovalidate-testing/package.json
@@ -15,7 +15,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@bufbuild/protobuf": "^2.6.1",
-    "@bufbuild/protovalidate": "^0.5.0",
+    "@bufbuild/protovalidate": "^0.6.0",
     "upstream": "*"
   }
 }

--- a/packages/protovalidate/package.json
+++ b/packages/protovalidate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufbuild/protovalidate",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Protocol Buffer Validation for ECMAScript",
   "keywords": [
     "javascript",


### PR DESCRIPTION
This release is compatible with the [v0.14.0](https://github.com/bufbuild/protovalidate/releases/tag/v0.14.0) release of Protovalidate.


## Breaking changes


We want validation rules to be easy to understand for authors and consumers. To simplify Protovalidate, we are renaming an option and remove two others. This is a breaking change, and you will have to update your Protobuf files if they use the relevant options :

- `IGNORE_IF_UNPOPULATED` is renamed to `IGNORE_IF_ZERO_VALUE`.
See https://github.com/bufbuild/protovalidate/pull/397 for details.
- `(buf.validate.message).disabled` is removed.
You can replace it by adding `IGNORE_ALWAYS` to every field of the message. See https://github.com/bufbuild/protovalidate/pull/394 for details.
- `IGNORE_IF_DEFAULT_VALUE` is removed.
In most cases, you can replace it with `IGNORE_IF_ZERO_VALUE`. See https://github.com/bufbuild/protovalidate/pull/396 for details.


## New Contributors
* @jrinehart-buf made their first contribution in https://github.com/bufbuild/protovalidate-es/pull/56

**Full Changelog**: https://github.com/bufbuild/protovalidate-es/compare/v0.5.0...v0.6.0