### PR TITLE
Update `violation(s)ToProto` to also return the descriptor

### DIFF
--- a/packages/protovalidate-testing/src/executor.ts
+++ b/packages/protovalidate-testing/src/executor.ts
@@ -52,7 +52,7 @@ for (const [name, any] of Object.entries(request.cases)) {
       case "invalid":
         testResult.result = {
           case: "validationError",
-          value: violationsToProto(result.violations),
+          value: violationsToProto(result.violations)[0],
         };
         break;
       case "error":

--- a/packages/protovalidate/src/error.test.ts
+++ b/packages/protovalidate/src/error.test.ts
@@ -70,7 +70,8 @@ void suite("violationToProto", () => {
       [],
       false,
     );
-    const proto = violationToProto(violation);
+    const [proto, desc] = violationToProto(violation);
+    assert.equal(desc, ViolationSchema);
     assert.ok(isMessage(proto, ViolationSchema));
     assert.equal(proto.message, violation.message);
     assert.equal(proto.ruleId, violation.ruleId);
@@ -95,7 +96,8 @@ void suite("violationToProto", () => {
       [],
       false,
     );
-    const proto = violationToProto(violation);
+    const [proto, desc] = violationToProto(violation);
+    assert.equal(desc, ViolationSchema);
     assert.ok(proto.field);
     assert.equal(proto.field.elements.length, 1);
     assert.equal(proto.field.elements[0].fieldName, "val");
@@ -118,7 +120,8 @@ void suite("violationToProto", () => {
       [],
       false,
     );
-    const proto = violationToProto(violation);
+    const [proto, desc] = violationToProto(violation);
+    assert.equal(desc, ViolationSchema);
     assert.ok(proto.field);
     assert.equal(proto.field.elements.length, 1);
     assert.equal(
@@ -147,7 +150,8 @@ void suite("violationToProto", () => {
       [],
       false,
     );
-    const proto = violationToProto(violation);
+    const [proto, desc] = violationToProto(violation);
+    assert.equal(desc, ViolationSchema);
     assert.ok(proto.field);
     assert.equal(proto.field.elements.length, 1);
     assert.equal(
@@ -167,7 +171,7 @@ void suite("violationToProto", () => {
       new Violation("message-1", "id-1", [], [], false),
       new Violation("message-2", "id-2", [], [], false),
     ];
-    const proto = violationsToProto(violations);
+    const [proto] = violationsToProto(violations);
     assert.ok(isMessage(proto, ViolationsSchema));
     assert.equal(proto.violations.length, violations.length);
   });
@@ -175,11 +179,12 @@ void suite("violationToProto", () => {
 
 void suite("pathFromViolationProto", () => {
   function toProto(path: Path): FieldPath {
-    const proto = violationsToProto([
+    const [proto] = violationsToProto([
       new Violation("message", "id", path, [], false),
-    ]).violations[0].field;
-    assert.ok(proto !== undefined);
-    return proto;
+    ]);
+    const field = proto.violations[0].field;
+    assert.ok(field !== undefined);
+    return field;
   }
   for (const { string, golden, schema, registry } of getTestDataForPaths()) {
     void test(string, () => {

--- a/packages/protovalidate/src/error.ts
+++ b/packages/protovalidate/src/error.ts
@@ -18,6 +18,8 @@ import {
   type FieldPathElement,
   FieldPathElementSchema,
   FieldPathSchema,
+  type Violations,
+  type Violation as ViolationProto,
   ViolationSchema,
   ViolationsSchema,
 } from "./gen/buf/validate/validate_pb.js";
@@ -153,26 +155,38 @@ export class Violation {
 }
 
 /**
- * Convert an array of Violation[] to the Protobuf message buf.validate.Violations.
+ * Convert an array of Violation[] to the Protobuf message buf.validate.Violations
+ * and return the message along with its descriptor.
  */
-export function violationsToProto(violation: Violation[]) {
-  return create(ViolationsSchema, {
-    violations: violation.map(violationToProto),
-  });
+export function violationsToProto(
+  violation: Violation[],
+): [Violations, typeof ViolationsSchema] {
+  return [
+    create(ViolationsSchema, {
+      violations: violation.map((v) => violationToProto(v)[0]),
+    }),
+    ViolationsSchema,
+  ];
 }
 
 /**
- * Convert a Violation to the Protobuf message buf.validate.Violation.
+ * Convert a Violation to the Protobuf message buf.validate.Violation
+ * and return the message along with its descriptor.
  */
-export function violationToProto(violation: Violation) {
-  return create(ViolationSchema, {
-    field:
-      violation.field.length > 0 ? pathToProto(violation.field) : undefined,
-    rule: violation.rule.length > 0 ? pathToProto(violation.rule) : undefined,
-    ruleId: violation.ruleId,
-    message: violation.message.length > 0 ? violation.message : undefined,
-    forKey: violation.forKey,
-  });
+export function violationToProto(
+  violation: Violation,
+): [ViolationProto, typeof ViolationSchema] {
+  return [
+    create(ViolationSchema, {
+      field:
+        violation.field.length > 0 ? pathToProto(violation.field) : undefined,
+      rule: violation.rule.length > 0 ? pathToProto(violation.rule) : undefined,
+      ruleId: violation.ruleId,
+      message: violation.message.length > 0 ? violation.message : undefined,
+      forKey: violation.forKey,
+    }),
+    ViolationSchema,
+  ];
 }
 
 /**


### PR DESCRIPTION
Update `violation(s)ToProto` to also return the descriptor. protobuf-es requires descriptors for most functions. Until we figure out a better way to distribute the gen files, retuning the descriptor is quite useful.