### PR TITLE
Release `0.8.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1813,11 +1813,11 @@
     },
     "packages/example": {
       "name": "protovalidate-example",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.6.2",
-        "@bufbuild/protovalidate": "^0.7.0"
+        "@bufbuild/protovalidate": "^0.8.0"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.56.0",
@@ -1827,7 +1827,7 @@
     },
     "packages/protovalidate": {
       "name": "@bufbuild/protovalidate",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/cel": "0.3.0"
@@ -1846,7 +1846,7 @@
       "name": "@bufbuild/protovalidate-testing",
       "devDependencies": {
         "@bufbuild/protobuf": "^2.6.2",
-        "@bufbuild/protovalidate": "^0.7.0",
+        "@bufbuild/protovalidate": "^0.8.0",
         "upstream": "*"
       }
     },

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protovalidate-example",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
@@ -15,7 +15,7 @@
   "type": "module",
   "dependencies": {
     "@bufbuild/protobuf": "^2.6.2",
-    "@bufbuild/protovalidate": "^0.7.0"
+    "@bufbuild/protovalidate": "^0.8.0"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.56.0",

--- a/packages/protovalidate-testing/package.json
+++ b/packages/protovalidate-testing/package.json
@@ -15,7 +15,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@bufbuild/protobuf": "^2.6.2",
-    "@bufbuild/protovalidate": "^0.7.0",
+    "@bufbuild/protovalidate": "^0.8.0",
     "upstream": "*"
   }
 }

--- a/packages/protovalidate/package.json
+++ b/packages/protovalidate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufbuild/protovalidate",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Protocol Buffer Validation for ECMAScript",
   "keywords": [
     "javascript",


### PR DESCRIPTION
## What's Changed
* Update `violation(s)ToProto` to also return the descriptor by @srikrsna-buf in https://github.com/bufbuild/protovalidate-es/pull/76

**Full Changelog**: https://github.com/bufbuild/protovalidate-es/compare/v0.7.0...v0.8.0