### PR TITLE
Release `1.1.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1831,11 +1831,11 @@
     },
     "packages/example": {
       "name": "protovalidate-example",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.10.2",
-        "@bufbuild/protovalidate": "^1.1.0"
+        "@bufbuild/protovalidate": "^1.1.1"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.62.1",
@@ -1845,7 +1845,7 @@
     },
     "packages/protovalidate": {
       "name": "@bufbuild/protovalidate",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/cel": "0.4.0"
@@ -1864,7 +1864,7 @@
       "name": "@bufbuild/protovalidate-testing",
       "devDependencies": {
         "@bufbuild/protobuf": "^2.10.2",
-        "@bufbuild/protovalidate": "^1.1.0",
+        "@bufbuild/protovalidate": "^1.1.1",
         "upstream": "*"
       }
     },

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protovalidate-example",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
@@ -15,7 +15,7 @@
   "type": "module",
   "dependencies": {
     "@bufbuild/protobuf": "^2.10.2",
-    "@bufbuild/protovalidate": "^1.1.0"
+    "@bufbuild/protovalidate": "^1.1.1"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.62.1",

--- a/packages/protovalidate-testing/package.json
+++ b/packages/protovalidate-testing/package.json
@@ -15,7 +15,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@bufbuild/protobuf": "^2.10.2",
-    "@bufbuild/protovalidate": "^1.1.0",
+    "@bufbuild/protovalidate": "^1.1.1",
     "upstream": "*"
   }
 }

--- a/packages/protovalidate/package.json
+++ b/packages/protovalidate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufbuild/protovalidate",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Protocol Buffer Validation for ECMAScript",
   "keywords": [
     "javascript",


### PR DESCRIPTION
This release is compatible with the [v1.1.0](https://github.com/bufbuild/protovalidate/releases/tag/v1.1.0) release of Protovalidate.

## What's Changed

Protovalidate CEL methods were previously also usable as functions due to a limitation in the CEL package.  This release uses an updated version that is able to distinguish between methods and functions. This is inline with other Protovalidate implementations.



**Full Changelog**: https://github.com/bufbuild/protovalidate-es/compare/v1.1.0...v1.1.1