### PR TITLE
Remove incomplete plan from cache when compilation fails

### DIFF
--- a/packages/protovalidate/src/planner.ts
+++ b/packages/protovalidate/src/planner.ts
@@ -96,11 +96,16 @@ export class Planner {
     const messageRules = getOption(message, ext_message);
     const e = new EvalMany<ReflectMessage>();
     this.messageCache.set(message, e);
-    e.add(this.fields(messageRules.oneof, message.fields));
-    e.add(this.messageCel(messageRules));
-    e.add(this.messageOneofs(message, messageRules.oneof));
-    e.add(this.oneofs(message.oneofs));
-    e.prune();
+    try {
+      e.add(this.fields(messageRules.oneof, message.fields));
+      e.add(this.messageCel(messageRules));
+      e.add(this.messageOneofs(message, messageRules.oneof));
+      e.add(this.oneofs(message.oneofs));
+      e.prune();
+    } catch (err) {
+      this.messageCache.delete(message);
+      throw err;
+    }
     return e;
   }
 

--- a/packages/protovalidate/src/validator.test.ts
+++ b/packages/protovalidate/src/validator.test.ts
@@ -329,6 +329,22 @@ void suite("Validator", () => {
       );
       assert.ok(result.error instanceof CompilationError);
     });
+    void test("unknown extension raises error on every call", () => {
+      const validator = createValidator();
+      const person = create(personSchema, {
+        name: "Pauly Shore",
+      });
+      const result = validator.validate(personSchema, person);
+      assert.equal(result.kind, "error", "first call should explode");
+      assert.ok(result.error instanceof CompilationError);
+      const retryResult = validator.validate(personSchema, person);
+      assert.equal(
+        retryResult.kind,
+        "error",
+        "second call should still explore, not silently skip the unknown extension and pass, buuddyy",
+      );
+      assert.ok(retryResult.error instanceof CompilationError);
+    });
     void test("registered extension validates", () => {
       const validator = createValidator({
         registry: createRegistry(ext_abc),

--- a/packages/protovalidate/src/validator.test.ts
+++ b/packages/protovalidate/src/validator.test.ts
@@ -341,7 +341,7 @@ void suite("Validator", () => {
       assert.equal(
         retryResult.kind,
         "error",
-        "second call should still explore, not silently skip the unknown extension and pass, buuddyy",
+        "second call should also explode",
       );
       assert.ok(retryResult.error instanceof CompilationError);
     });


### PR DESCRIPTION
When an unregistered rule is hit during planning a `CompilationError` is thrown (as of #106), when this happens the partial plan stays in the message cache so next time through it picks up the partial cache and returns the incomplete plan.

In our case this resulted in:
- Failed first call
- Passed second call because the field that would have triggered validation wasn't being validated

This catches the error and removes the incomplete message from the cache so it will fail again consistently.