### PR TITLE
Release `v1.2.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1831,11 +1831,11 @@
     },
     "packages/example": {
       "name": "protovalidate-example",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
-        "@bufbuild/protovalidate": "^1.1.1"
+        "@bufbuild/protovalidate": "^1.2.0"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.62.1",
@@ -1845,7 +1845,7 @@
     },
     "packages/protovalidate": {
       "name": "@bufbuild/protovalidate",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/cel": "0.4.0"
@@ -1864,7 +1864,7 @@
       "name": "@bufbuild/protovalidate-testing",
       "devDependencies": {
         "@bufbuild/protobuf": "^2.11.0",
-        "@bufbuild/protovalidate": "^1.1.1",
+        "@bufbuild/protovalidate": "^1.2.0",
         "upstream": "*"
       }
     },

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protovalidate-example",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
@@ -15,7 +15,7 @@
   "type": "module",
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
-    "@bufbuild/protovalidate": "^1.1.1"
+    "@bufbuild/protovalidate": "^1.2.0"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.62.1",

--- a/packages/protovalidate-testing/package.json
+++ b/packages/protovalidate-testing/package.json
@@ -15,7 +15,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@bufbuild/protobuf": "^2.11.0",
-    "@bufbuild/protovalidate": "^1.1.1",
+    "@bufbuild/protovalidate": "^1.2.0",
     "upstream": "*"
   }
 }

--- a/packages/protovalidate/package.json
+++ b/packages/protovalidate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufbuild/protovalidate",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Protocol Buffer Validation for ECMAScript",
   "keywords": [
     "javascript",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yaml at main -->

This release is compatible with the [v1.2.0](https://github.com/bufbuild/protovalidate/releases/tag/v1.2.0) release of Protovalidate.

## What's Changed
* Update protovalidate to `v1.2.0` by @srikrsna-buf in https://github.com/bufbuild/protovalidate-es/pull/143
* Remove incomplete plan from cache when compilation fails by @dbrain in https://github.com/bufbuild/protovalidate-es/pull/137

## New Contributors
* @dbrain made their first contribution in https://github.com/bufbuild/protovalidate-es/pull/137

**Full Changelog**: https://github.com/bufbuild/protovalidate-es/compare/v1.1.1...v1.2.0