### PR TITLE
Prune dead evaluators recursively

### DIFF
--- a/packages/protovalidate/src/eval.ts
+++ b/packages/protovalidate/src/eval.ts
@@ -173,8 +173,20 @@ export class EvalField<F extends DescField> implements Eval<ReflectMessage> {
       this.pass.eval(fieldVal, cursor.field(this.field));
     }
   }
+  private pruning = false;
   prune(): boolean {
-    return this.condition.never && !this.required && !this.legacyRequired;
+    let passDead = false;
+    // Plans for recursive message types are cyclic; don't recurse twice.
+    if (!this.pruning) {
+      this.pruning = true;
+      passDead = this.pass.prune();
+      this.pruning = false;
+    }
+    return (
+      (this.condition.never || passDead) &&
+      !this.required &&
+      !this.legacyRequired
+    );
   }
 }
 


### PR DESCRIPTION
Compiled validation plans rely on a post-planning `prune()` pass to remove evaluators that can never produce a violation. The planner deliberately over-builds: it attaches an `EvalCustomCel` to every field whether or not the field has custom CEL rules, and expects pruning to clean up after it.

`EvalField.prune()` never recursed into its value sub-plan, so pruning stopped at every field boundary and dead nodes below fields survived into the runtime tree. The empty `EvalCustomCel` under every field is the expensive case: its `eval()` binds three CEL environment entries and converts the field value into CEL's value model before iterating zero children. That work runs per field, per `validate()` call, for custom rules that don't exist. In a CPU profile of a hot validation loop over a schema with no custom rules, `setEnv` alone was 13.6% of samples.

The `pruning` variable and guard exists because plans for recursive message types can be cyclic.

Unit tests and the conformance suite pass identically before and after. `packages/protovalidate-bench` is faster on all 13 tasks, −4% to −29% (Map −29%, Repeated/Scalar −25%, ComplexSchema −9%).

[bench-repo-main.txt](https://github.com/user-attachments/files/31796723/bench-repo-main.txt)
[bench-repo-prunefix.txt](https://github.com/user-attachments/files/31796724/bench-repo-prunefix.txt)
