### PR TITLE
Compute the 'now' CEL variable lazily

### DIFF
--- a/packages/protovalidate/src/cel.ts
+++ b/packages/protovalidate/src/cel.ts
@@ -80,13 +80,14 @@ export type CelCompiledRule =
 
 export class CelManager {
   // CEL environment with extensions for Protovalidate.
-  // This includes the variable "now", which must be updated before each evaluation
-  // by calling updateCelNow().
+  // This includes the variable "now", which is memoized for the duration of
+  // a single validation; validate() clears it via resetNow().
   private readonly env: CelEnv;
   private readonly rulesCache = new Map<string, CelCompiledRules>();
   private readonly bindings: Partial<
     Record<"this" | "rules" | "rule" | "now", CelInput>
   > = {};
+  private now: CelInput | undefined;
 
   constructor(
     private readonly registry: Registry,
@@ -96,14 +97,24 @@ export class CelManager {
       registry,
       funcs: [...strings, ...createCustomFuncions(regexMatcher)],
     });
-    this.bindings.now = timestampNow();
+    // Computing a Timestamp is comparatively expensive and most rules never
+    // read "now", so the binding computes on first access and memoizes until
+    // resetNow(). The memo keeps "now" stable within a single validation.
+    Object.defineProperty(this.bindings, "now", {
+      enumerable: true,
+      get: (): CelInput => {
+        this.now ??= timestampNow();
+        return this.now;
+      },
+    });
   }
 
   /**
-   * Update the CEL variable "now" to the current time.
+   * Forget the memoized CEL variable "now", so the next evaluation that reads
+   * it sees the current time.
    */
-  updateCelNow(): void {
-    this.bindings.now = timestampNow();
+  resetNow(): void {
+    this.now = undefined;
   }
 
   setEnv(

--- a/packages/protovalidate/src/cel.ts
+++ b/packages/protovalidate/src/cel.ts
@@ -86,7 +86,7 @@ export class CelManager {
   private readonly rulesCache = new Map<string, CelCompiledRules>();
   private readonly bindings: Partial<
     Record<"this" | "rules" | "rule" | "now", CelInput>
-  > = {};
+  >;
   private now: CelInput | undefined;
 
   constructor(
@@ -97,16 +97,16 @@ export class CelManager {
       registry,
       funcs: [...strings, ...createCustomFuncions(regexMatcher)],
     });
-    // Computing a Timestamp is comparatively expensive and most rules never
-    // read "now", so the binding computes on first access and memoizes until
-    // resetNow(). The memo keeps "now" stable within a single validation.
-    Object.defineProperty(this.bindings, "now", {
-      enumerable: true,
-      get: (): CelInput => {
-        this.now ??= timestampNow();
-        return this.now;
+    const manager = this;
+    this.bindings = {
+      // Computing a Timestamp is comparatively expensive and most rules never
+      // read "now", so the binding computes on first access and memoizes until
+      // resetNow(). The memo keeps "now" stable within a single validation.
+      get now(): CelInput {
+        manager.now ??= timestampNow();
+        return manager.now;
       },
-    });
+    };
   }
 
   /**

--- a/packages/protovalidate/src/validator.test.ts
+++ b/packages/protovalidate/src/validator.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as assert from "node:assert";
-import { suite, test } from "node:test";
+import { suite, test, type TestContext } from "node:test";
 import { readFileSync } from "node:fs";
 import { expectTypeOf } from "expect-type";
 import {
@@ -22,7 +22,11 @@ import {
   type DescMessage,
   type Message,
 } from "@bufbuild/protobuf";
-import { DurationSchema, TimestampSchema } from "@bufbuild/protobuf/wkt";
+import {
+  DurationSchema,
+  type Timestamp,
+  TimestampSchema,
+} from "@bufbuild/protobuf/wkt";
 import type { GenMessage } from "@bufbuild/protobuf/codegenv2";
 import { compileFile, compileMessage } from "@bufbuild/protocompile";
 import {
@@ -540,5 +544,105 @@ void suite("MessageOneofRule", () => {
       result.error?.message,
       `field "xxx" not found in message Example`,
     );
+  });
+});
+
+void suite("CEL variable now", () => {
+  void test("is fresh for each validation", (t) => {
+    // timestampNow() reads the clock through new Date().
+    t.mock.timers.enable({ apis: ["Date"], now: 1_000_000_000_000 });
+    type M = Message<"M"> & { ts?: Timestamp };
+    const schema = compileMessage(
+      `
+      syntax = "proto3";
+      import "buf/validate/validate.proto";
+      import "google/protobuf/timestamp.proto";
+      message M {
+        google.protobuf.Timestamp ts = 1 [(buf.validate.field).timestamp.lt_now = true];
+      }
+      `,
+      bufCompileOptions,
+    ) as GenMessage<M>;
+    const validator = createValidator();
+    // One second in the (mocked) future: not less than now.
+    const msg = create(schema, {
+      ts: create(TimestampSchema, { seconds: 1_000_000_001n }),
+    });
+    assert.strictEqual(validator.validate(schema, msg).kind, "invalid");
+    // Two seconds later, the same timestamp is in the past. "now" is
+    // memoized only for the duration of a single validation, so the second
+    // validation must see the new time.
+    t.mock.timers.tick(2000);
+    assert.strictEqual(validator.validate(schema, msg).kind, "valid");
+  });
+
+  // Mock the clock: each parameterless new Date() returns a time one hour
+  // later than the last. timestampNow() reads the clock through new Date().
+  // Returns a counter of those reads.
+  function installAdvancingClock(t: TestContext): () => number {
+    const RealDate = globalThis.Date;
+    let nowMs = 1_000_000_000_000;
+    const mocked = t.mock.method(
+      globalThis,
+      "Date",
+      class extends RealDate {
+        constructor(ms?: number) {
+          if (ms === undefined) {
+            nowMs += 3_600_000;
+            ms = nowMs;
+          }
+          super(ms);
+        }
+      } as DateConstructor,
+    );
+    return () =>
+      mocked.mock.calls.filter((call) => call.arguments.length === 0).length;
+  }
+
+  void test("is read at most once per validation", (t) => {
+    installAdvancingClock(t);
+    const schema = compileMessage(
+      `
+      syntax = "proto3";
+      import "buf/validate/validate.proto";
+      message M {
+        option (buf.validate.message).cel = {
+          id: "now_is_stable"
+          message: "now must be stable within a validation"
+          expression: "now == now"
+        };
+      }
+      `,
+      bufCompileOptions,
+    );
+    const validator = createValidator();
+    // Every uncached clock read returns a different time, so this can only
+    // be valid if both reads of "now" see the same memoized value.
+    assert.strictEqual(
+      validator.validate(schema, create(schema)).kind,
+      "valid",
+    );
+  });
+
+  void test("is not computed when no rule reads it", (t) => {
+    const reads = installAdvancingClock(t);
+    type M = Message<"M"> & { x: number };
+    const schema = compileMessage(
+      `
+      syntax = "proto3";
+      import "buf/validate/validate.proto";
+      message M {
+        int32 x = 1 [(buf.validate.field).int32.gt = 0];
+      }
+      `,
+      bufCompileOptions,
+    ) as GenMessage<M>;
+    const validator = createValidator();
+    const msg = create(schema, { x: 1 });
+    // First validation compiles the plan; ignore any reads during setup.
+    validator.validate(schema, msg);
+    const before = reads();
+    assert.strictEqual(validator.validate(schema, msg).kind, "valid");
+    assert.strictEqual(reads(), before);
   });
 });

--- a/packages/protovalidate/src/validator.ts
+++ b/packages/protovalidate/src/validator.ts
@@ -216,7 +216,12 @@ function validateUnsafe(
   const plan = planner.plan(schema);
   const msg = reflect(schema, message);
   const cursor = Cursor.create(schema, failFast);
-  celMan.updateCelNow();
-  plan.eval(msg, cursor);
+  celMan.resetNow();
+  try {
+    plan.eval(msg, cursor);
+  } finally {
+    // The memoized "now" must not outlive the validation of this message.
+    celMan.resetNow();
+  }
   cursor.throwIfViolated();
 }

--- a/packages/protovalidate/src/validator.ts
+++ b/packages/protovalidate/src/validator.ts
@@ -216,7 +216,6 @@ function validateUnsafe(
   const plan = planner.plan(schema);
   const msg = reflect(schema, message);
   const cursor = Cursor.create(schema, failFast);
-  celMan.resetNow();
   try {
     plan.eval(msg, cursor);
   } finally {


### PR DESCRIPTION
time.Now() was being called for each call to validate(). With this change it will lazily call time.Now() and cache it for the duration of that validate() call, so multiple rules that need to know the time will only trigger time.Now() a single time.

`packages/protovalidate-bench` runs 2–8% faster on the lighter tasks (Scalar −6.8%, Map −7.5%).